### PR TITLE
Add shutdown_timeout as environment variable

### DIFF
--- a/watchdog/README.md
+++ b/watchdog/README.md
@@ -100,6 +100,7 @@ The watchdog can be configured through environmental variables. You must always 
 | `read_timeout`         | HTTP timeout for reading the payload from the client caller (in seconds) |
 | `suppress_lock`        | The watchdog will attempt to write a lockfile to /tmp/ for swarm healthchecks - set this to true to disable behaviour. |
 | `exec_timeout`         | Hard timeout for process exec'd for each incoming request (in seconds). Disabled if set to 0 |
+| `shutdown_timeout`     | Graceful shutdowns will last a least twice this number (in seconds). See section: *Graceful shutdowns* for more detail. Defaults to `write_timeout` |
 | `write_debug`          | Write all output, error messages, and additional information to the logs. Default is false |
 | `combine_output`       | True by default - combines stdout/stderr in function response, when set to false `stderr` is written to the container logs and stdout is used for function response |
 | `max_inflight`         | Limit the maximum number of requests in flight |
@@ -120,11 +121,11 @@ This re-write is mainly structural for on-going maintenance. It will be a drop-i
 
 The watchdog is capable of working with health-checks to provide a graceful shutdown.
 
-When a `SIGTERM` signal is detected within the watchdog process a Go routine will remove the `/tmp/.lock` file and mark the HTTP health-check as unhealthy and return HTTP 503. The code will then wait for the duration specified in `write_timeout`. During this window the container-orchestrator's health-check must run and complete.
+When a `SIGTERM` signal is detected within the watchdog process a Go routine will remove the `/tmp/.lock` file and mark the HTTP health-check as unhealthy and return HTTP 503. The code will then wait for the duration specified in `shutdown_timeout`. During this window the container-orchestrator's health-check must run and complete.
 
 Now the orchestrator will mark this replica as unhealthy and remove it from the pool of valid HTTP endpoints.
 
-Now we will stop accepting new connections and wait for the value defined in `write_timeout` before finally allowing the process to exit.
+Now we will stop accepting new connections and wait for the value defined in `shutdown_timeout` before finally allowing the process to exit.
 
 ### Working with HTTP headers
 

--- a/watchdog/main.go
+++ b/watchdog/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	go metricsServer.Serve(cancel)
 
-	shutdownTimeout := config.writeTimeout
+	shutdownTimeout := config.shutdownTimeout
 	listenUntilShutdown(shutdownTimeout, s, config.suppressLock)
 }
 

--- a/watchdog/readconfig.go
+++ b/watchdog/readconfig.go
@@ -66,6 +66,7 @@ func (ReadConfig) Read(hasEnv HasEnv) WatchdogConfig {
 
 	cfg.readTimeout = parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), time.Second*5)
 	cfg.writeTimeout = parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), time.Second*5)
+	cfg.shutdownTimeout = parseIntOrDurationValue(hasEnv.Getenv("shutdown_timeout"), cfg.writeTimeout)
 
 	cfg.execTimeout = parseIntOrDurationValue(hasEnv.Getenv("exec_timeout"), time.Second*0)
 	cfg.port = parseIntValue(hasEnv.Getenv("port"), 8080)
@@ -111,6 +112,11 @@ type WatchdogConfig struct {
 
 	// duration until the faasProcess will be killed
 	execTimeout time.Duration
+
+	// when SIGTERM is sent the server will wait `shutdownTimeout` before
+	// closing off connections and a futher `shutdownTimeout` before exiting
+	// defaults to `writeTimeout` if not specified
+	shutdownTimeout time.Duration
 
 	// writeDebug write console stdout statements to the container
 	writeDebug bool


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add `shutdown_timeout` as an environment variable to configure the grace shutdown timeout. See https://github.com/openfaas/faas/issues/1559 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally with kind. Set up as follow:

1. Create an fprocess that lasts 20 seconds
2. Set `shutdown_timeout` to 1 second and `write_timeout` to 30 seconds
3. Start the fprocess from Postman, run `kubect delete pod <podname>` quickly and manully inspect that the fprocess are allowed to finish while only waiting 1 second for the pod to terminate after fprocess are finished.

I have also verified that the previous behaviour works as expected when not specifying the `shutdown_timeout` environment variable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
