### PR TITLE
Remove request_duration_seconds metrics from gateway

### DIFF
--- a/gateway/metrics/metrics.go
+++ b/gateway/metrics/metrics.go
@@ -67,14 +67,6 @@ func BuildMetricsOptions() MetricOptions {
 		[]string{"function_name"},
 	)
 
-	// For automatic monitoring and alerting (RED method)
-	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Subsystem: "http",
-		Name:      "request_duration_seconds",
-		Help:      "Seconds spent serving HTTP requests.",
-		Buckets:   prometheus.DefBuckets,
-	}, []string{"method", "path", "status"})
-
 	// Can be used Kubernetes HPA v2
 	counter := prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
Due to flooding of victoriametrics. See [this thread](https://cognitedata.slack.com/archives/C6Q390MBJ/p1619434440057600).